### PR TITLE
clipboard.to_wide: fix return type

### DIFF
--- a/vlib/clipboard/clipboard_windows.v
+++ b/vlib/clipboard/clipboard_windows.v
@@ -117,7 +117,7 @@ fn to_wide(text string) &HGLOBAL {
         locked[len_required - 1] = u16(0)
         GlobalUnlock(buf)
     }
-    return buf
+    return &buf
 }
 
 fn (cb mut Clipboard) set_text(text string) bool {


### PR DESCRIPTION
error: fn `clipboard.to_wide` expects you to return a reference type `&C.HGLOBAL`, but you are returning `C.HGLOBAL` instead

Ran into this issue during running the UI examples.

Changed the return type to a reference.